### PR TITLE
Add Japanese text toggling and text display speed functionality.

### DIFF
--- a/index.css
+++ b/index.css
@@ -7,36 +7,26 @@ body {
 }
 
 #controls {
-  margin: 2rem;
+  padding: 2rem;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.5) 25%,
+    rgba(0, 0, 0, 0.35) 50%,
+    rgba(0, 0, 0, 0.2) 75%,
+    rgba(0, 0, 0, 0) 100%
+  );
   display: none;
+  justify-content: space-between;
+}
+
+#more-options {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 #episode {
   display: none;
-}
-
-#update {
-  float: right;
-  position: relative;
-}
-
-#updated-at {
-  visibility: hidden;
-  width: 120px;
-  background-color: black;
-  color: #fff;
-  text-align: center;
-  padding: 5px 0;
-  border-radius: 6px;
-  top: 100%;
-  left: 50%;
-  margin-left: -60px;
-  position: absolute;
-  z-index: 1;
-}
-
-#update:hover #updated-at {
-  visibility: visible;
 }
 
 #updating {
@@ -82,6 +72,7 @@ body {
 .textStroke {
   -webkit-text-stroke: 1px black;
 }
+
 #name {
   text-shadow: #000 0px 0px 5px, #000 0px 0px 5px, #000 0px 0px 5px,
     #000 0px 0px 5px, #000 0px 0px 5px, #000 0px 0px 5px, #000 0px 0px 5px,
@@ -89,6 +80,7 @@ body {
   font-weight: 600;
   font-size: 2.2rem;
 }
+
 #text-en {
   margin: 0;
   text-shadow: #000 0px 0px 3px, #000 0px 0px 3px, #000 0px 0px 3px,
@@ -98,6 +90,7 @@ body {
   position: absolute;
   top: 25%;
 }
+
 #text-jp {
   text-shadow: #000 0px 0px 3px, #000 0px 0px 3px, #000 0px 0px 3px,
     #000 0px 0px 3px, #000 0px 0px 3px, #000 0px 0px 3px;
@@ -106,4 +99,18 @@ body {
   position: fixed;
   bottom: 2%;
   font-size: 1rem;
+}
+
+#text-speed {
+  margin: 0 12px;
+}
+
+label {
+  color: white;
+  text-shadow: #000 0px 0px 3px, #000 0px 0px 3px, #000 0px 0px 3px,
+    #000 0px 0px 3px, #000 0px 0px 3px, #000 0px 0px 3px;
+}
+
+.hide {
+  display: none;
 }

--- a/index.html
+++ b/index.html
@@ -12,21 +12,35 @@
   </head>
   <body>
     <div id="controls">
-      <select name="chapter" id="chapter">
-        <option value="Prologue">Prologue</option>
-        <option value="Chapter1">Chapter 1</option>
-        <option value="Chapter2">Chapter 2</option>
-        <option value="Chapter3">Chapter 3</option>
-        <option value="Chapter4">Chapter 4</option>
-        <option value="LastChapter">Last Chapter</option>
-        <option value="ExtraChapter">Extra Chapter</option>
-        <option value="Episodes">Episodes --></option>
-      </select>
-      <select name="episode" id="episode"></select>
-      <input type="number" min="0" id="line-number" />
-      <button type="button" id="update">
-        Update translations<span id="updated-at"></span>
-      </button>
+      <div id="chapter-options">
+        <select name="chapter" id="chapter">
+          <option value="Prologue">Prologue</option>
+          <option value="Chapter1">Chapter 1</option>
+          <option value="Chapter2">Chapter 2</option>
+          <option value="Chapter3">Chapter 3</option>
+          <option value="Chapter4">Chapter 4</option>
+          <option value="LastChapter">Last Chapter</option>
+          <option value="ExtraChapter">Extra Chapter</option>
+          <option value="Episodes">Episodes --></option>
+        </select>
+        <select name="episode" id="episode"></select>
+        <input type="number" min="0" id="line-number">
+      </div>
+      <div id="more-options">
+        <div>
+          <input type="checkbox" id="checkbox-hide-text-jp" name="checkbox-hide-text-jp">
+          <label for="checkbox-hide-text-jp">Hide Japanese Text</label>
+        </div>
+        <select name="text-speed" id="text-speed">
+          <option value="30">Slow</option>
+          <option value="20">Normal</option>
+          <option value="10">Fast</option>
+          <option value="0">Immediate</option>
+        </select>
+        <button type="button" id="update">
+          Update translations
+        </button>
+      </div>
     </div>
     <div id="updating">Updating translations, please wait...</div>
     <div id="dialog">

--- a/parseXlsx.js
+++ b/parseXlsx.js
@@ -60,7 +60,7 @@ function saveAppData(name, content) {
   }
 
   const appDataFilePath = path.join(appDataDirPath, name);
-  content = JSON.stringify(content);
+  content = JSON.stringify(content, null, 2);
 
   fs.writeFile(appDataFilePath, content, (err) => {
     if (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ registerKeyHandlers({
   Tab: () => {
     const controls = document.getElementById("controls");
     if (controls.style.display === "none") {
-      controls.style.display = "block";
+      controls.style.display = "flex";
     } else {
       controls.style.display = "none";
     }


### PR DESCRIPTION
Thanks for creating this great tool! This PR adds a bit of functionality (tested in Chapter 1 of Hajimari no kiseki) in order to better match the existing overlay tool.

- Adds a checkbox for toggle on and off the Japanese text in order to match the existing overlay. Allows this to be saved in local storage.
- Adds a text speed select dropdown with 4 options -- slow, normal, fast, and immediate. Allows this to be saved in local storage.
- Moves the Translations `Updated At` hover text to a `title` attribute on the button. This simplifies that code and still displays it on hover.
- Fixes a bug by sanitizing the excel content so that lines start with `<` are displayed properly (previously they weren't displaying at all).
- Pretty-prints the translations.json file so that it was easier to examine (not that it is necessary, but I was looking into it and felt like doing so would be nice for debugging the translations file).

Happy to split this up into separate PRs if necessary.

|Screenshots (the text and the paused game are not in sync; this was just for testing an area of text that had `<`)|
|-----------|
|<img width="1439" alt="Screen Shot 2020-11-24 at 2 41 16 PM" src="https://user-images.githubusercontent.com/1585774/100160467-7d604300-2e64-11eb-9a77-e55e068e85da.png">|
|<img width="1438" alt="Screen Shot 2020-11-24 at 2 41 10 PM" src="https://user-images.githubusercontent.com/1585774/100160468-7f2a0680-2e64-11eb-85c9-7b20ed313246.png">|
|<img width="1437" alt="Screen Shot 2020-11-24 at 2 40 50 PM" src="https://user-images.githubusercontent.com/1585774/100160545-a385e300-2e64-11eb-9c98-147fc6889c09.png">|