### PR TITLE
Fix rendering bug when a spreadsheet cell only contains a number

### DIFF
--- a/parseXlsx.js
+++ b/parseXlsx.js
@@ -29,6 +29,7 @@ module.exports = function downloadAndParseTranslations(cb) {
             xlsx.utils
               .sheet_to_json(file.Sheets[name], {
                 header: ["name", "en", "jp"],
+                blankrows: true,
               })
               .slice(name === "Prologue" ? 22 : 1),
           ])
@@ -36,6 +37,7 @@ module.exports = function downloadAndParseTranslations(cb) {
         Episodes: xlsx.utils
           .sheet_to_json(file.Sheets["Episodes"], {
             header: ["name", "en", "jp", "flag"],
+            blankrows: true,
           })
           .slice(1)
           .reduce(

--- a/src/dialogManager.js
+++ b/src/dialogManager.js
@@ -161,7 +161,7 @@ function typeWriter(txt = "") {
       "/": "&#x2F;",
     };
     const reg = /[&<>"'/]/ig;
-    return string.replace(reg, (match) => (map[match]));
+    return String(string).replace(reg, (match) => (map[match]));
   }
 
   function typeCharacter() {


### PR DESCRIPTION
While playing Chapter 1, a cell in the spreadsheet consisted only of the number `1`, which resulted in a bug because `1.replace()` is not a function.

This PR addresses that bug by coercing all rows first to a primitive String before calling replace. `String(variable)` will return a string in all instances, even with `null`, `undefined`, and an object. Although the result isn't always ideal, it at least won't fail.

I've also added functionality to include blank rows in the translations, as they are usually included to signal a conversation change in the spreadsheet and can be helpful so you don't spoil yourself (clicking next and then seeing a blank row means you can probably turn off the text until the next piece of dialog instead of accidentally reading the first line of the next conversation).