### PR TITLE
Darken text background and general code cleanup

### DIFF
--- a/index.css
+++ b/index.css
@@ -44,28 +44,30 @@ body {
 
 #dialog {
   background: rgb(0, 0, 0);
-  background: rgb(0, 0, 0);
-  background: rgb(0, 0, 0);
   background: linear-gradient(
     0deg,
     rgba(0, 0, 0, 1) 0%,
-    rgba(0, 0, 0, 0.85) 25%,
-    rgba(0, 0, 0, 0.6) 50%,
-    rgba(0, 0, 0, 0.4) 75%,
+    rgba(0, 0, 0, 0.85) 60%,
+    rgba(0, 0, 0, 0.7) 75%,
+    rgba(0, 0, 0, 0.5) 85%,
+    rgba(0, 0, 0, 0.4) 90%,
+    rgba(0, 0, 0, 0.2) 95%,
     rgba(0, 0, 0, 0) 100%
   );
   position: fixed;
   bottom: 0%;
   width: 100%;
-  height: 205px;
+  min-height: 232px;
+}
+
+#dialog.hide-text-jp {
+  min-height: 180px;
 }
 
 #text-box {
-  height: 205px;
-  position: fixed;
-  left: 19%;
-  right: 19%;
-  bottom: 0%;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 5rem;
   color: white;
 }
 
@@ -82,13 +84,11 @@ body {
 }
 
 #text-en {
-  margin: 0;
+  margin: 0.5rem 0 0;
   text-shadow: #000 0px 0px 3px, #000 0px 0px 3px, #000 0px 0px 3px,
     #000 0px 0px 3px, #000 0px 0px 3px, #000 0px 0px 3px;
   font-weight: 600;
   font-size: 1.5rem;
-  position: absolute;
-  top: 25%;
 }
 
 #text-jp {
@@ -96,8 +96,6 @@ body {
     #000 0px 0px 3px, #000 0px 0px 3px, #000 0px 0px 3px;
   font-family: "Sawarabi Gothic";
   margin-top: 2.5rem;
-  position: fixed;
-  bottom: 2%;
   font-size: 1rem;
 }
 

--- a/src/dialogManager.js
+++ b/src/dialogManager.js
@@ -5,19 +5,19 @@ let currentChapter = "Prologue";
 let currentEpisode = "0";
 let timeout;
 let currentLineSpeed;
-let textSpeed;
-let hideJapaneseText;
-let finished = true;
+let lines;
+let textSpeed = 20;
+let isLineFinished = true;
 
-const textSpeedSelect = document.getElementById("text-speed");
-const textSpeedOptions = textSpeedSelect.options;
+const dialogContainer = document.getElementById("dialog");
 
-function setupTextSpeed() {
-  textSpeed = localStorage.getItem("textSpeed");
-  if (textSpeed) {
-    textSpeed = parseInt(textSpeed);
-  } else {
-    textSpeed = 20;
+function initializeTextSpeed() {
+  const textSpeedSelect = document.getElementById("text-speed");
+  const textSpeedOptions = textSpeedSelect.options;
+
+  const savedTextSpeed = localStorage.getItem("textSpeed");
+  if (savedTextSpeed) {
+    textSpeed = parseInt(savedTextSpeed);
   }
 
   Array.apply(null, textSpeedOptions).some(function(option, index) {
@@ -35,86 +35,97 @@ function setupTextSpeed() {
   });
 }
 
-setupTextSpeed();
-
-const savedChapter = localStorage.getItem("currentChapter");
-if (savedChapter) {
-  currentChapter = savedChapter;
-}
-const savedEpisode = localStorage.getItem("currentEpisode");
-if (savedEpisode) {
-  currentEpisode = savedEpisode;
-}
-
-let lines;
-if (currentChapter === "Episodes") {
-  lines = chapters.Episodes[parseInt(currentEpisode)];
-  document.getElementById("episode").style.display = "inline";
-} else {
-  lines = chapters[currentChapter];
-}
-
-const savedLine = localStorage.getItem("currentLine");
-if (savedLine) {
-  lines.current = parseInt(savedLine);
-  render(lines[lines.current]);
-}
-
-document.getElementById("chapter").addEventListener("change", (evt) => {
-  currentChapter = evt.target.value;
-  if (currentChapter === "Episodes") {
-    document.getElementById("episode").style.display = "inline";
-    lines = chapters.Episodes[parseInt(currentEpisode)];
-  } else {
-    document.getElementById("episode").style.display = "none";
-    lines = chapters[currentChapter];
+function initializeTextPosition() {
+  const savedChapter = localStorage.getItem("currentChapter");
+  if (savedChapter) {
+    currentChapter = savedChapter;
   }
-  render(lines.next());
-});
 
-document.getElementById("episode").addEventListener("change", (evt) => {
-  currentEpisode = evt.target.value;
-  lines = chapters.Episodes[parseInt(currentEpisode)];
-  render(lines.next());
-});
+  const savedEpisode = localStorage.getItem("currentEpisode");
+  if (savedEpisode) {
+    currentEpisode = savedEpisode;
+  }
 
-document.getElementById("line-number").addEventListener("change", (evt) => {
-  lines.current = parseInt(evt.target.value) - 1;
-  render(lines.next());
-});
-
-document.getElementById("update").addEventListener("click", async (evt) => {
-  document.getElementById("updating").style.display = "block";
-  document.getElementById("update").disabled = true;
-  await updateTranslations();
-  document.getElementById("updating").style.display = "none";
-  document.getElementById("update").disabled = false;
   if (currentChapter === "Episodes") {
     lines = chapters.Episodes[parseInt(currentEpisode)];
     document.getElementById("episode").style.display = "inline";
   } else {
     lines = chapters[currentChapter];
   }
+
   const savedLine = localStorage.getItem("currentLine");
-  lines.current = parseInt(savedLine);
-  render(lines[lines.current]);
-});
-
-const hideJapaneseCheckbox = document.getElementById("checkbox-hide-text-jp");
-const textJPElement = document.getElementById("text-jp");
-hideJapaneseText = localStorage.getItem("hideJapaneseText");
-if (hideJapaneseText === "true") {
-  hideJapaneseCheckbox.checked = true;
-  textJPElement.classList.add("hide");
-}
-hideJapaneseCheckbox.addEventListener("click", function(evt) {
-  textJPElement.classList.toggle("hide");
-  if (textJPElement.classList.contains("hide")) {
-    localStorage.setItem("hideJapaneseText", "true");
-  } else {
-    localStorage.setItem("hideJapaneseText", "false");
+  if (savedLine) {
+    lines.current = parseInt(savedLine);
+    render(lines[lines.current]);
   }
-});
+
+  document.getElementById("chapter").addEventListener("change", (evt) => {
+    currentChapter = evt.target.value;
+    if (currentChapter === "Episodes") {
+      document.getElementById("episode").style.display = "inline";
+      lines = chapters.Episodes[parseInt(currentEpisode)];
+    } else {
+      document.getElementById("episode").style.display = "none";
+      lines = chapters[currentChapter];
+    }
+    render(lines.next());
+  });
+
+  document.getElementById("episode").addEventListener("change", (evt) => {
+    currentEpisode = evt.target.value;
+    lines = chapters.Episodes[parseInt(currentEpisode)];
+    render(lines.next());
+  });
+
+  document.getElementById("line-number").addEventListener("change", (evt) => {
+    lines.current = parseInt(evt.target.value) - 1;
+    render(lines.next());
+  });
+}
+
+function initalizeUpdateTranslations() {
+  document.getElementById("update").addEventListener("click", async (evt) => {
+    document.getElementById("updating").style.display = "block";
+    document.getElementById("update").disabled = true;
+    await updateTranslations();
+    document.getElementById("updating").style.display = "none";
+    document.getElementById("update").disabled = false;
+
+    if (currentChapter === "Episodes") {
+      lines = chapters.Episodes[parseInt(currentEpisode)];
+      document.getElementById("episode").style.display = "inline";
+    } else {
+      lines = chapters[currentChapter];
+    }
+
+    const savedLine = localStorage.getItem("currentLine");
+    lines.current = parseInt(savedLine);
+    render(lines[lines.current]);
+  });
+}
+
+function initializeHideJapaneseText() {
+  const hideJapaneseCheckbox = document.getElementById("checkbox-hide-text-jp");
+  const textJPElement = document.getElementById("text-jp");
+  const savedHideJapaneseTextStatus = localStorage.getItem("hideJapaneseText");
+
+  if (savedHideJapaneseTextStatus === "true") {
+    hideJapaneseCheckbox.checked = true;
+    textJPElement.classList.add("hide");
+    dialogContainer.classList.add("hide-text-jp");
+  }
+
+  hideJapaneseCheckbox.addEventListener("click", function(evt) {
+    textJPElement.classList.toggle("hide");
+    dialogContainer.classList.toggle("hide-text-jp");
+
+    if (textJPElement.classList.contains("hide")) {
+      localStorage.setItem("hideJapaneseText", "true");
+    } else {
+      localStorage.removeItem("hideJapaneseText");
+    }
+  });
+}
 
 function render(line) {
   const chapter = document.getElementById("chapter");
@@ -145,7 +156,7 @@ function typeWriter(txt = "") {
   const english = document.getElementById("text-en");
   english.innerText = "";
   currentLineSpeed = textSpeed;
-  finished = false;
+  isLineFinished = false;
 
   function* iterateText() {
     yield* txt;
@@ -167,7 +178,7 @@ function typeWriter(txt = "") {
   function typeCharacter() {
     if (currentLineSpeed == 0) {
       english.innerHTML = sanitize(txt);
-      finished = true;
+      isLineFinished = true;
       return;
     }
     const character = characters.next();
@@ -175,7 +186,7 @@ function typeWriter(txt = "") {
       english.innerHTML += sanitize(character.value);
       timeout = setTimeout(typeCharacter, currentLineSpeed);
     } else {
-      finished = true;
+      isLineFinished = true;
     }
   }
 
@@ -185,7 +196,7 @@ function typeWriter(txt = "") {
 }
 
 export function advanceText() {
-  if (!finished) {
+  if (!isLineFinished) {
     currentLineSpeed = 0;
     return;
   }
@@ -202,10 +213,14 @@ export function backwardText() {
 
 export function freezeText() {
   textFrozen = !textFrozen;
-  const textBox = document.getElementById("dialog");
   if (textFrozen) {
-    textBox.style.display = "none";
+    dialogContainer.style.display = "none";
   } else {
-    textBox.style.display = "block";
+    dialogContainer.style.display = "block";
   }
 }
+
+initializeTextSpeed();
+initializeTextPosition();
+initalizeUpdateTranslations();
+initializeHideJapaneseText();


### PR DESCRIPTION
This PR addresses...

- The black gradient background for the text didn't always display clearly when the game display behind it was bright or had text of its own. I've made the background gradient darker for longer and added a few more steps. 
- Removed some redundant `position: fixed` related styles for the text container at the bottom seeing as their parent class was already fixed, so we can position everything within it relatively.
- Made the overlay smaller when Japanese text is hidden and allowed for the entire text container to be entirely responsive depending on how many lines of text there are to display (default `min-height` handles 2 rows of English text as I haven't run into 3 rows of English text so far).
- Tried to compartmentalize a bit of the `dialogManager.js` code into logical chunks so that it's more clear what the different lines relate to. More than happy to move this to a separate PR or refactor it all, as moving to their own functions isn't necessarily the ideal endgoal here.